### PR TITLE
Set XDG_DATA_DIRS

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -120,6 +120,7 @@ export APPDIR="${APPDIR:-"$(dirname "$(realpath "$0")")"}" # Workaround to run e
 export GTK_DATA_PREFIX="$APPDIR"
 export GTK_THEME="$APPIMAGE_GTK_THEME" # Custom themes are broken
 export GDK_BACKEND=x11 # Crash with Wayland backend on Wayland
+export XDG_DATA_DIRS="$APPDIR/usr/share:/usr/share:$XDG_DATA_DIRS" # g_get_system_data_dirs() from GLib
 EOF
 
 echo "Installing GLib schemas"


### PR DESCRIPTION
This is required by some applications to work. GLib uses `XDG_DATA_DIRS` in functions like `g_get_system_data_dirs()`
https://developer.gnome.org/glib/stable/glib-Miscellaneous-Utility-Functions.html#g-get-system-data-dirs