### PR TITLE
Remove libgio from AppImage

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -178,12 +178,10 @@ fi
 
 echo "Copying more libraries"
 gobject_libdir="$("$PKG_CONFIG" --variable=libdir gobject-2.0)"
-gio_libdir="$("$PKG_CONFIG" --variable=libdir gio-2.0)"
 librsvg_libdir="$("$PKG_CONFIG" --variable=libdir librsvg-2.0)"
 FIND_ARRAY=(
     "$gdk_libdir"     "libgdk_pixbuf-*.so*"
     "$gobject_libdir" "libgobject-*.so*"
-    "$gio_libdir"     "libgio-*.so*"
     "$librsvg_libdir" "librsvg-*.so*"
 )
 LIBRARIES=()

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -91,7 +91,7 @@ else
     exit 1
 fi
 
-if ! which patchelf &>/dev/null && ! type patchelf &>/dev/null; then
+if ! command -v patchelf &>/dev/null && ! type patchelf &>/dev/null; then
     echo -e "$0: patchelf not found.\nInstall patchelf then re-run the plugin."
     exit 1
 fi


### PR DESCRIPTION
Hello,

I have issues with AppImage on Arch Linux and Fedora 33:
```
symbol lookup error: /usr/lib/libpangoft2-1.0.so.0: undefined symbol: g_task_set_name
```
There is an incompatibility with GIO (bundled in AppImage) and Cairo (system library). This issue seems to affect other libraries like GVFS.

Removing libgio.so from AppImage does not seem to introduce regression on Ubuntu 16.04 and 20.04, and it fixes issue on Arch Linux and Fedora 33.