### PR TITLE
Fix for #16

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -178,10 +178,12 @@ fi
 
 echo "Copying more libraries"
 gobject_libdir="$("$PKG_CONFIG" --variable=libdir gobject-2.0)"
+gio_libdir="$("$PKG_CONFIG" --variable=libdir gio-2.0)"
 librsvg_libdir="$("$PKG_CONFIG" --variable=libdir librsvg-2.0)"
 FIND_ARRAY=(
     "$gdk_libdir"     "libgdk_pixbuf-*.so*"
     "$gobject_libdir" "libgobject-*.so*"
+    "$gio_libdir"     "libgio-*.so*"
     "$librsvg_libdir" "librsvg-*.so*"
 )
 LIBRARIES=()

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -180,11 +180,17 @@ echo "Copying more libraries"
 gobject_libdir="$("$PKG_CONFIG" --variable=libdir gobject-2.0)"
 gio_libdir="$("$PKG_CONFIG" --variable=libdir gio-2.0)"
 librsvg_libdir="$("$PKG_CONFIG" --variable=libdir librsvg-2.0)"
+pango_libdir="$("$PKG_CONFIG" --variable=libdir pango)"
+pangocairo_libdir="$("$PKG_CONFIG" --variable=libdir pangocairo)"
+pangoft2_libdir="$("$PKG_CONFIG" --variable=libdir pangoft2)"
 FIND_ARRAY=(
     "$gdk_libdir"     "libgdk_pixbuf-*.so*"
     "$gobject_libdir" "libgobject-*.so*"
     "$gio_libdir"     "libgio-*.so*"
     "$librsvg_libdir" "librsvg-*.so*"
+    "$pango_libdir"      "libpango-*.so*"
+    "$pangocairo_libdir" "libpangocairo-*.so*"
+    "$pangoft2_libdir"   "libpangoft2-*.so*"
 )
 LIBRARIES=()
 for (( i=0; i<${#FIND_ARRAY[@]}; i+=2 )); do


### PR DESCRIPTION
#15 introduced a regression with GIO modules, according to #16.

As a reminder, in b02d75305a60fb4d4d1a6d726ea75176a15efb3e, I tried to fix the following error:
```
symbol lookup error: /usr/lib/libpangoft2-1.0.so.0: undefined symbol: g_task_set_name
```

But it introduces a regression, hence the revert with c010b17.

So I looked for another way to fix the original issue: adding Cairo libraries (592df98) solves the issue.
