### PR TITLE
GTK 4 support

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -4,13 +4,14 @@ on: [push, pull_request]
 
 jobs:
   containers:
-    name: Buildah
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         gtk-version: [gtk3, gtk4]
         linux-distro: [debian, fedora, opensuse, ubuntu]
+
+    name: ${{ matrix.linux-distro }} ${{ matrix.gtk-version }}
+    runs-on: ubuntu-latest
+
     env:
       GTK_VERSION: ${{ matrix.gtk-version }}
       LINUX_DISTRO: ${{ matrix.linux-distro }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -26,7 +26,7 @@ jobs:
           mkdir -pv "${ARTIFACT_DIR}"
           buildah bud \
             --squash \
-            -v "${ARTIFACT_DIR}:/AppImage:rw,z,U" \
+            -v "${ARTIFACT_DIR}:/AppImage:rw,z,shared" \
             -t "linuxdeploy-plugin-${GTK_VERSION}:${LINUX_DISTRO}" \
             -f "containers/${GTK_VERSION}/Dockerfile.${LINUX_DISTRO}" \
             .

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,37 @@
+name: Containers
+
+on: [push, pull_request]
+
+jobs:
+  containers:
+    name: Buildah
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        gtk-version: [gtk3, gtk4]
+        linux-distro: [debian, fedora, opensuse, ubuntu]
+    env:
+      GTK_VERSION: ${{ matrix.gtk-version }}
+      LINUX_DISTRO: ${{ matrix.linux-distro }}
+      ARTIFACT_DIR: "${{ github.workspace }}/AppImages"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build container
+        run: |
+          mkdir -pv "${ARTIFACT_DIR}"
+          buildah bud \
+            --squash \
+            -v "${ARTIFACT_DIR}:/AppImage:rw,z,U" \
+            -t "linuxdeploy-plugin-${GTK_VERSION}:${LINUX_DISTRO}" \
+            -f "containers/${GTK_VERSION}/Dockerfile.${LINUX_DISTRO}" \
+            .
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "${LINUX_DISTRO} with ${GTK_VERSION}"
+          path: "${ARTIFACT_DIR}/"
+          retention-days: 30

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -33,6 +33,6 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: "${LINUX_DISTRO} with ${GTK_VERSION}"
-          path: "${ARTIFACT_DIR}/"
+          name: ${{ matrix.linux-distro }} with ${{ matrix.gtk-version }}
+          path: ${{ env.ARTIFACT_DIR }}/
           retention-days: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ jobs:
     name: Linux x64_64
     runs-on: ubuntu-latest
 
+    env:
+      DEPLOY_GTK3: 1
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         echo "REPODIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
         echo "APPDIR=/tmp/AppDir"        >> $GITHUB_ENV
+        echo "DEPLOY_GTK_VERSION=3"      >> $GITHUB_ENV
 
     - name: Setup dependencies
       run: |
@@ -32,7 +33,7 @@ jobs:
 
     - name: Run test script
       run: |
-        mkdir -pv "$APPDIR"
+        mkdir -pv "$APPDIR/usr/bin"
         ./test-plugins.sh
 
     - name: Display files inside AppDir

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,16 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DEPLOY_GTK3: 1
+      REPODIR: "${{ github.workspace }}"
+      APPDIR: "/tmp/AppDir"
+      DEPLOY_GTK_VERSION: 3
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Set environment variables
-      run: |
-        echo "REPODIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-        echo "APPDIR=/tmp/AppDir"        >> $GITHUB_ENV
-        echo "DEPLOY_GTK_VERSION=3"      >> $GITHUB_ENV
 
     - name: Setup dependencies
       run: |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This is an (as of yet experimental) plugin for linuxdeploy. Its job is to bundle additional resources for applications that use GTK, and for common dependencies. Those involve GLib schemas for instance.
 
+## Dependencies
+
+This plugin requires the following dependencies in order to work properly:
+
+- `patchelf` command
+- `file` command
+- `find` command
+- `pkg-config` or `pkgconf` command
+- librsvg2 development files
+- GTK development files
 
 ## Usage
 
@@ -9,6 +19,9 @@ This is an (as of yet experimental) plugin for linuxdeploy. Its job is to bundle
 # get linuxdeploy and linuxdeploy-plugin-gtk
 > wget -c "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
 > wget -c "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+
+# get list of variables
+> ./linuxdeploy-plugin-gtk.sh --help 
 
 # first option: install your app into your AppDir via `make install` etc.
 # second option: bundle your app's main executables manually

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # linuxdeploy-plugin-gtk
 
-This is an (as of yet experimental) plugin for linuxdeploy. Its job is to bundle additional resources for applications that use Gtk+ 2 or 3, and for common dependencies. Those involve GLib schemas for instance.
+This is an (as of yet experimental) plugin for linuxdeploy. Its job is to bundle additional resources for applications that use GTK, and for common dependencies. Those involve GLib schemas for instance.
 
 
 ## Usage

--- a/containers/gtk3/Dockerfile.debian
+++ b/containers/gtk3/Dockerfile.debian
@@ -1,0 +1,26 @@
+FROM docker.io/debian:buster AS build-stage
+WORKDIR /linuxdeploy
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ENV DEBIAN_FRONTEND=noninteractive
+ARG APPDIR=/AppDir
+ARG TZ=UTC
+RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
+RUN apt-get update && \
+    apt-get install -y wget patchelf librsvg2-dev file findutils pkg-config libgtk-3-0 libgtk-3-dev gtk-3-examples
+COPY . .
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
+RUN chmod +x *.sh *.AppImage
+RUN ./linuxdeploy-x86_64.AppImage \
+    --appdir ${APPDIR} \
+    --plugin gtk \
+    --output appimage \
+    --executable /usr/bin/gtk3-widget-factory \
+    --desktop-file /usr/share/applications/gtk3-widget-factory.desktop \
+    --icon-file /usr/share/icons/hicolor/256x256/apps/gtk3-widget-factory.png
+
+FROM docker.io/debian:buster
+VOLUME ["/AppImage"]
+WORKDIR /AppImage
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
+ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]

--- a/containers/gtk3/Dockerfile.fedora
+++ b/containers/gtk3/Dockerfile.fedora
@@ -1,0 +1,22 @@
+FROM docker.io/fedora:33 AS build-stage
+WORKDIR /linuxdeploy
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ARG APPDIR=/AppDir
+RUN dnf install -y wget patchelf librsvg2-devel file findutils pkgconfig gtk3 gtk3-devel
+COPY . .
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
+RUN chmod +x *.sh *.AppImage
+RUN ./linuxdeploy-x86_64.AppImage \
+    --appdir ${APPDIR} \
+    --plugin gtk \
+    --output appimage \
+    --executable /usr/bin/gtk3-widget-factory \
+    --desktop-file /usr/share/applications/gtk3-widget-factory.desktop \
+    --icon-file /usr/share/icons/hicolor/256x256/apps/gtk3-widget-factory.png
+
+FROM docker.io/fedora:33
+VOLUME ["/AppImage"]
+WORKDIR /AppImage
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
+ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]

--- a/containers/gtk3/Dockerfile.opensuse
+++ b/containers/gtk3/Dockerfile.opensuse
@@ -1,0 +1,22 @@
+FROM docker.io/opensuse/leap:15 AS build-stage
+WORKDIR /linuxdeploy
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ARG APPDIR=/AppDir
+RUN zypper install -y wget patchelf librsvg2-devel file findutils pkg-config gtk3 gtk3-devel
+COPY . .
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
+RUN chmod +x *.sh *.AppImage
+RUN ./linuxdeploy-x86_64.AppImage \
+    --appdir ${APPDIR} \
+    --plugin gtk \
+    --output appimage \
+    --executable /usr/bin/gtk3-widget-factory \
+    --desktop-file /usr/share/applications/gtk3-widget-factory.desktop \
+    --icon-file /usr/share/icons/hicolor/256x256/apps/gtk3-widget-factory.png
+
+FROM docker.io/opensuse/leap:15
+VOLUME ["/AppImage"]
+WORKDIR /AppImage
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
+ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]

--- a/containers/gtk3/Dockerfile.ubuntu
+++ b/containers/gtk3/Dockerfile.ubuntu
@@ -1,0 +1,26 @@
+FROM docker.io/ubuntu:focal AS build-stage
+WORKDIR /linuxdeploy
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ENV DEBIAN_FRONTEND=noninteractive
+ARG APPDIR=/AppDir
+ARG TZ=UTC
+RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
+RUN apt-get update && \
+    apt-get install -y wget patchelf librsvg2-dev file findutils pkg-config libgtk-3-0 libgtk-3-dev gtk-3-examples
+COPY . .
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
+RUN chmod +x *.sh *.AppImage
+RUN ./linuxdeploy-x86_64.AppImage \
+    --appdir ${APPDIR} \
+    --plugin gtk \
+    --output appimage \
+    --executable /usr/bin/gtk3-widget-factory \
+    --desktop-file /usr/share/applications/gtk3-widget-factory.desktop \
+    --icon-file /usr/share/icons/hicolor/256x256/apps/gtk3-widget-factory.png
+
+FROM docker.io/ubuntu:focal
+VOLUME ["/AppImage"]
+WORKDIR /AppImage
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
+ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]

--- a/containers/gtk4/Dockerfile.debian
+++ b/containers/gtk4/Dockerfile.debian
@@ -1,0 +1,28 @@
+# GTK4 is not yet supported on Debian Stable
+FROM docker.io/debian:experimental AS build-stage
+WORKDIR /linuxdeploy
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ENV DEBIAN_FRONTEND=noninteractive
+ARG APPDIR=/AppDir
+ARG TZ=UTC
+RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
+RUN apt-get update && \
+    apt-get install -y wget patchelf librsvg2-dev file findutils pkg-config && \
+    apt-get install -y -t experimental libgtk-4-1 libgtk-4-dev gtk-4-examples
+COPY . .
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
+RUN chmod +x *.sh *.AppImage
+RUN ./linuxdeploy-x86_64.AppImage \
+    --appdir ${APPDIR} \
+    --plugin gtk \
+    --output appimage \
+    --executable /usr/bin/gtk4-widget-factory \
+    --desktop-file /usr/share/applications/org.gtk.WidgetFactory4.desktop \
+    --icon-file /usr/share/icons/hicolor/scalable/apps/org.gtk.WidgetFactory4.svg
+
+FROM docker.io/debian:experimental
+VOLUME ["/AppImage"]
+WORKDIR /AppImage
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
+ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]

--- a/containers/gtk4/Dockerfile.fedora
+++ b/containers/gtk4/Dockerfile.fedora
@@ -1,0 +1,22 @@
+FROM docker.io/fedora:33 AS build-stage
+WORKDIR /linuxdeploy
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ARG APPDIR=/AppDir
+RUN dnf install -y wget patchelf librsvg2-devel file findutils pkgconfig gtk4 gtk4-devel
+COPY . .
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
+RUN chmod +x *.sh *.AppImage
+RUN ./linuxdeploy-x86_64.AppImage \
+    --appdir ${APPDIR} \
+    --plugin gtk \
+    --output appimage \
+    --executable /usr/bin/gtk4-widget-factory \
+    --desktop-file /usr/share/applications/org.gtk.WidgetFactory4.desktop \
+    --icon-file /usr/share/icons/hicolor/scalable/apps/org.gtk.WidgetFactory4.svg
+
+FROM docker.io/fedora:33
+VOLUME ["/AppImage"]
+WORKDIR /AppImage
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
+ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]

--- a/containers/gtk4/Dockerfile.opensuse
+++ b/containers/gtk4/Dockerfile.opensuse
@@ -1,0 +1,23 @@
+# GTK4 is not yet supported on openSUSE Leap
+FROM docker.io/opensuse/tumbleweed:latest AS build-stage
+WORKDIR /linuxdeploy
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ARG APPDIR=/AppDir
+RUN zypper install -y wget patchelf librsvg2-devel file findutils pkg-config gtk4 gtk4-devel
+COPY . .
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
+RUN chmod +x *.sh *.AppImage
+RUN ./linuxdeploy-x86_64.AppImage \
+    --appdir ${APPDIR} \
+    --plugin gtk \
+    --output appimage \
+    --executable /usr/bin/gtk4-widget-factory \
+    --desktop-file /usr/share/applications/org.gtk.WidgetFactory4.desktop \
+    --icon-file /usr/share/icons/hicolor/scalable/apps/org.gtk.WidgetFactory4.svg
+
+FROM docker.io/opensuse/tumbleweed:latest
+VOLUME ["/AppImage"]
+WORKDIR /AppImage
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
+ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]

--- a/containers/gtk4/Dockerfile.ubuntu
+++ b/containers/gtk4/Dockerfile.ubuntu
@@ -1,0 +1,26 @@
+FROM docker.io/ubuntu:hirsute AS build-stage
+WORKDIR /linuxdeploy
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+ENV DEBIAN_FRONTEND=noninteractive
+ARG APPDIR=/AppDir
+ARG TZ=UTC
+RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
+RUN apt-get update && \
+    apt-get install -y wget patchelf librsvg2-dev file findutils pkg-config libgtk-4-1 libgtk-4-dev gtk-4-examples
+COPY . .
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
+RUN chmod +x *.sh *.AppImage
+RUN ./linuxdeploy-x86_64.AppImage \
+    --appdir ${APPDIR} \
+    --plugin gtk \
+    --output appimage \
+    --executable /usr/bin/gtk4-widget-factory \
+    --desktop-file /usr/share/applications/org.gtk.WidgetFactory4.desktop \
+    --icon-file /usr/share/icons/hicolor/scalable/apps/org.gtk.WidgetFactory4.svg
+
+FROM docker.io/ubuntu:hirsute
+VOLUME ["/AppImage"]
+WORKDIR /AppImage
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
+ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -84,8 +84,8 @@ search_tool() {
     done
 }
 
+DEPLOY_GTK_VERSION="${DEPLOY_GTK_VERSION:-0}" # When not set by user, this variable use the integer '0' as a sentinel value
 APPDIR=
-DEPLOY_GTK_VERSION="${DEPLOY_GTK_VERSION:-0}"
 
 while [ "$1" != "" ]; do
     case "$1" in

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -108,6 +108,11 @@ else
     exit 1
 fi
 
+if ! command -v find &>/dev/null && ! type find &>/dev/null; then
+    echo -e "$0: find not found.\nInstall findutils then re-run the plugin."
+    exit 1
+fi
+
 if ! command -v patchelf &>/dev/null && ! type patchelf &>/dev/null; then
     echo -e "$0: patchelf not found.\nInstall patchelf then re-run the plugin."
     exit 1


### PR DESCRIPTION
Hello,

This PR add GTK 4 support in linuxdeploy-plugin-gtk. According to [this message](https://gitlab.gnome.org/GNOME/gtk/-/issues/1181#note_255975), GTK+ 4.0 do not support IM modules.
I removed explicit mentions to GTK 2 and GTK 3 to cover GTK 4.

I added Dockerfiles to test the plugin with a GTK3 and a GTK4 application (the widget factory) on Debian, Fedora, openSUSE and Ubuntu.
There is an minor issue on the GitHub Runner with the shared volume (`/AppImage` inside containers), but I do not have this problem locally. It does not matter, because the volume store built AppImages and we do not really need them in fact.

Please note this PR is based on #19.