### PR TITLE
Improve tempdir name

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -177,14 +177,14 @@ HOOKSDIR="$APPDIR/apprun-hooks"
 HOOKFILE="$HOOKSDIR/linuxdeploy-plugin-gtk.sh"
 mkdir -p "$HOOKSDIR"
 cat > "$HOOKFILE" <<\EOF
-#! /bin/bash
+#! /usr/bin/env bash
 
 gsettings get org.gnome.desktop.interface gtk-theme 2> /dev/null | grep -qi "dark" && GTK_THEME_VARIANT="dark" || GTK_THEME_VARIANT="light"
 APPIMAGE_GTK_THEME="${APPIMAGE_GTK_THEME:-"Adwaita:$GTK_THEME_VARIANT"}" # Allow user to override theme (discouraged)
 
 # in case we run from an AppImage, we use the $APPDIR environment variable as a template for the temporary directory that should be created
 # this allows users to attribute the tempdir to the running AppImage
-if [[ "$APPDIR" != "" ]]; then
+if [ "$APPDIR" != "" ]; then
     tempdir_template="$APPDIR".ld-p-gtk-tmp
 else
     tempdir_template=/tmp/.ld-p-gtk-tmp-XXXXXX

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -181,7 +181,16 @@ cat > "$HOOKFILE" <<\EOF
 
 gsettings get org.gnome.desktop.interface gtk-theme 2> /dev/null | grep -qi "dark" && GTK_THEME_VARIANT="dark" || GTK_THEME_VARIANT="light"
 APPIMAGE_GTK_THEME="${APPIMAGE_GTK_THEME:-"Adwaita:$GTK_THEME_VARIANT"}" # Allow user to override theme (discouraged)
-CACHEDIR="$(mktemp -d /tmp/.AppRun.XXXXXXXX)"
+
+# in case we run from an AppImage, we use the $APPDIR environment variable as a template for the temporary directory that should be created
+# this allows users to attribute the tempdir to the running AppImage
+if [[ "$APPDIR" != "" ]]; then
+    tempdir_template="$APPDIR".ld-p-gtk-tmp
+else
+    tempdir_template=/tmp/.ld-p-gtk-tmp-XXXXXX
+fi
+
+CACHEDIR="$(mktemp -d "$tempdir_template")"
 
 export APPDIR="${APPDIR:-"$(dirname "$(realpath "$0")")"}" # Workaround to run extracted AppImage
 export GTK_DATA_PREFIX="$APPDIR"


### PR DESCRIPTION
This PR changes the naming of the generated tempdir. Instead of using a completely random name, a (partly random) suffix is appended to `$APPDIR`, i.e., the mountpoint directory name. When running from an AppDir directly, the name uses a fixed template. Both templates include the string `ld-p-gtk` to show that it's the plugin's hook script which creates the AppDir and not some other component.

The second commit fixes an oversight @probonopd's last PR #25, where the wrong shebang was edited.