### PR TITLE
Fix gtk path

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -98,6 +98,8 @@ if [ "$APPDIR" == "" ]; then
 fi
 
 mkdir -p "$APPDIR"
+# make lib64 writable again.
+chmod +w "$APPDIR"/usr/lib64
 
 if command -v pkgconf > /dev/null; then
     PKG_CONFIG="pkgconf"
@@ -233,7 +235,7 @@ for directory in "${PATCH_ARRAY[@]}"; do
     done < <(find "$directory" -name '*.so' -print0)
 done
 
-#binary patch absolute paths
-#find $APPDIR/usr/lib/ -type f -exec sed -i -e "s|/usr|././|g" {} \;
+# set write permission on lib64 again to make it deletable.
+chmod +w "$APPDIR"/usr/lib64
 #binary patch absolute paths in libwebkit files
 find $APPDIR/usr/lib* -name libwebkit* -exec sed -i -e "s|/usr|././|g" '{}' \;

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -237,5 +237,16 @@ done
 
 # set write permission on lib64 again to make it deletable.
 chmod +w "$APPDIR"/usr/lib64 || true
+
+# We have to copy the files first to not get permission errors when we assign gio_extras_dir
+find /usr/lib* -name libgiognutls.so -exec mkdir -p "$APPDIR"/$(dirname '{}') \; -exec cp --parents '{}' "$APPDIR/" \; || true
+# related files that we seemingly don't need:
+# libgiolibproxy.so - libgiognomeproxy.so - glib-pacrunner
+
+gio_extras_dir=$(find "$APPDIR"/usr/lib* -name libgiognutls.so -exec dirname '{}' \; 2>/dev/null)
+cat >> "$HOOKFILE" <<EOF
+export GIO_EXTRA_MODULES="\$APPDIR/${gio_extras_dir#$APPDIR/}"
+EOF
+
 #binary patch absolute paths in libwebkit files
 find $APPDIR/usr/lib* -name libwebkit* -exec sed -i -e "s|/usr|././|g" '{}' \;

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -53,7 +53,6 @@ search_tool() {
     PATH_ARRAY=(
         "/usr/lib/$(uname -m)-linux-gnu/$directory/$tool"
         "/usr/lib/$directory/$tool"
-        "/usr/lib64/$directory/$tool"#fedora
         "/usr/bin/$tool"
         "/usr/bin/$tool-64"
         "/usr/bin/$tool-32"

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -53,6 +53,7 @@ search_tool() {
     PATH_ARRAY=(
         "/usr/lib/$(uname -m)-linux-gnu/$directory/$tool"
         "/usr/lib/$directory/$tool"
+        "/usr/lib64/$directory/$tool"#fedora
         "/usr/bin/$tool"
         "/usr/bin/$tool-64"
         "/usr/bin/$tool-32"
@@ -232,3 +233,8 @@ for directory in "${PATCH_ARRAY[@]}"; do
         patchelf --set-rpath '$ORIGIN/../../../..' "$APPDIR/$file"
     done < <(find "$directory" -name '*.so' -print0)
 done
+
+#binary patch absolute paths
+#find usr/lib/ -type f -exec sed -i -e "s|/usr|././|g" {} \;
+#binary patch absolute paths in libwebkit files
+find usr/lib* -name libwebkit* -exec sed -i -e "s|/usr|././|g" '{}' \;

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -20,9 +20,9 @@ show_usage() {
     echo
     echo "Required variables:"
     echo "  LINUXDEPLOY=\".../linuxdeploy\" path to linuxdeploy (e.g., AppImage); set automatically when plugin is run directly by linuxdeploy"
-    echo
-    echo "Optional variables:"
-    echo "  DEPLOY_GTK_VERSION (major version of GTK to deploy, e.g. '2', '3' or '4'; auto-detect by default)"
+    #echo
+    #echo "Optional variables:"
+    #echo "  DEPLOY_GTK_VERSION (major version of GTK to deploy, e.g. '2', '3' or '4'; auto-detect by default)"
 }
 
 variable_is_true() {
@@ -85,7 +85,8 @@ search_tool() {
     done
 }
 
-DEPLOY_GTK_VERSION="${DEPLOY_GTK_VERSION:-0}" # When not set by user, this variable use the integer '0' as a sentinel value
+#DEPLOY_GTK_VERSION="${DEPLOY_GTK_VERSION:-0}" # When not set by user, this variable use the integer '0' as a sentinel value
+DEPLOY_GTK_VERSION=3 # Force GTK3 for tauri apps
 APPDIR=
 
 while [ "$1" != "" ]; do

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -317,14 +317,14 @@ done
 chmod +w "$APPDIR"/usr/lib64 || true
 
 # We have to copy the files first to not get permission errors when we assign gio_extras_dir
-find /usr/lib* -name libgiognutls.so -exec mkdir -p "$APPDIR"/$(dirname '{}') \; -exec cp --parents '{}' "$APPDIR/" \; || true
+find /usr/lib* -name libgiognutls.so -exec mkdir -p "$APPDIR"/"$(dirname '{}')" \; -exec cp --parents '{}' "$APPDIR/" \; || true
 # related files that we seemingly don't need:
 # libgiolibproxy.so - libgiognomeproxy.so - glib-pacrunner
 
 gio_extras_dir=$(find "$APPDIR"/usr/lib* -name libgiognutls.so -exec dirname '{}' \; 2>/dev/null)
 cat >> "$HOOKFILE" <<EOF
-export GIO_EXTRA_MODULES="\$APPDIR/${gio_extras_dir#$APPDIR/}"
+export GIO_EXTRA_MODULES="\$APPDIR/${gio_extras_dir#"$APPDIR"/}"
 EOF
 
 #binary patch absolute paths in libwebkit files
-find $APPDIR/usr/lib* -name libwebkit* -exec sed -i -e "s|/usr|././|g" '{}' \;
+find "$APPDIR"/usr/lib* -name 'libwebkit*' -exec sed -i -e "s|/usr|././|g" '{}' \;

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -235,6 +235,6 @@ for directory in "${PATCH_ARRAY[@]}"; do
 done
 
 #binary patch absolute paths
-#find usr/lib/ -type f -exec sed -i -e "s|/usr|././|g" {} \;
+#find $APPDIR/usr/lib/ -type f -exec sed -i -e "s|/usr|././|g" {} \;
 #binary patch absolute paths in libwebkit files
-find usr/lib* -name libwebkit* -exec sed -i -e "s|/usr|././|g" '{}' \;
+find $APPDIR/usr/lib* -name libwebkit* -exec sed -i -e "s|/usr|././|g" '{}' \;

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -99,7 +99,7 @@ fi
 
 mkdir -p "$APPDIR"
 # make lib64 writable again.
-chmod +w "$APPDIR"/usr/lib64
+chmod +w "$APPDIR"/usr/lib64 2>/dev/null
 
 if command -v pkgconf > /dev/null; then
     PKG_CONFIG="pkgconf"
@@ -236,6 +236,6 @@ for directory in "${PATCH_ARRAY[@]}"; do
 done
 
 # set write permission on lib64 again to make it deletable.
-chmod +w "$APPDIR"/usr/lib64
+chmod +w "$APPDIR"/usr/lib64 2>/dev/null
 #binary patch absolute paths in libwebkit files
 find $APPDIR/usr/lib* -name libwebkit* -exec sed -i -e "s|/usr|././|g" '{}' \;

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -213,7 +213,7 @@ case "$DEPLOY_GTK_VERSION" in
         copy_tree "$gtk3_libdir" "$APPDIR/"
         cat >> "$HOOKFILE" <<EOF
 export GTK_EXE_PREFIX="\$APPDIR/$gtk3_exec_prefix"
-export GTK_PATH="\$APPDIR/$gtk3_libdir"
+export GTK_PATH="\$APPDIR/$gtk3_libdir:/usr/lib64/gtk-3.0:/usr/lib/x86_64-linux-gnu/gtk-3.0"
 export GTK_IM_MODULE_FILE="\$APPDIR/$gtk3_immodules_cache_file"
 
 EOF

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -205,7 +205,7 @@ case "$DEPLOY_GTK_VERSION" in
         echo "Installing GTK 3.0 modules"
         gtk3_exec_prefix="$(get_pkgconf_variable "exec_prefix" "gtk+-3.0")"
         gtk3_libdir="$(get_pkgconf_variable "libdir" "gtk+-3.0")/gtk-3.0"
-        gtk3_path="$gtk3_libdir/modules"
+        #gtk3_path="$gtk3_libdir/modules" export GTK_PATH="\$APPDIR/$gtk3_path"
         gtk3_immodulesdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0")/immodules"
         gtk3_printbackendsdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0")/printbackends"
         gtk3_immodules_cache_file="$(dirname "$gtk3_immodulesdir")/immodules.cache"
@@ -213,7 +213,7 @@ case "$DEPLOY_GTK_VERSION" in
         copy_tree "$gtk3_libdir" "$APPDIR/"
         cat >> "$HOOKFILE" <<EOF
 export GTK_EXE_PREFIX="\$APPDIR/$gtk3_exec_prefix"
-export GTK_PATH="\$APPDIR/$gtk3_path"
+export GTK_PATH="\$APPDIR/$gtk3_libdir"
 export GTK_IM_MODULE_FILE="\$APPDIR/$gtk3_immodules_cache_file"
 
 EOF

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -99,7 +99,7 @@ fi
 
 mkdir -p "$APPDIR"
 # make lib64 writable again.
-chmod +w "$APPDIR"/usr/lib64 2>/dev/null
+chmod +w "$APPDIR"/usr/lib64 || true
 
 if command -v pkgconf > /dev/null; then
     PKG_CONFIG="pkgconf"
@@ -236,6 +236,6 @@ for directory in "${PATCH_ARRAY[@]}"; do
 done
 
 # set write permission on lib64 again to make it deletable.
-chmod +w "$APPDIR"/usr/lib64 2>/dev/null
+chmod +w "$APPDIR"/usr/lib64 || true
 #binary patch absolute paths in libwebkit files
 find $APPDIR/usr/lib* -name libwebkit* -exec sed -i -e "s|/usr|././|g" '{}' \;


### PR DESCRIPTION
This PR is about the `Gtk-Message: Failed to load module X` warnings.

- first commit: removed the `modules` path segment from `GTK_PATH` so that it can actually find the modules folder
- second commit: i added 2 common _absolute_ paths of the modules folder so that gtk can fall back to modules present on the user's system since there are files we just can't bundle (and we don't know which ones are needed either since they are requested by the system, not the appimage).
  - The only concern i had here were version conflicts, but i did quite extensive testing and wasn't able to find _any_ problems. Therefore i'm just gonna use the release candidate for a live test.