### PR TITLE
Add Support for Typelib Packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup dependencies
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install -y -qq libgtk-3-0 libgtk-3-dev wget tree
+        sudo apt-get install -y -qq libgtk-3-0 libgtk-3-dev gir1.2-gtk-3.0 wget tree
 
     - name: Download external binairies
       run: |

--- a/containers/gtk3/Dockerfile.debian
+++ b/containers/gtk3/Dockerfile.debian
@@ -6,7 +6,8 @@ ARG APPDIR=/AppDir
 ARG TZ=UTC
 RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
 RUN apt-get update && \
-    apt-get install -y wget librsvg2-dev file findutils pkg-config libgtk-3-0 libgtk-3-dev gtk-3-examples
+    apt-get install -y wget librsvg2-dev file findutils pkg-config libgtk-3-0 \
+    libgtk-3-dev gtk-3-examples gir1.2-gtk-3.0
 COPY . .
 ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
 RUN chmod +x *.sh *.AppImage

--- a/containers/gtk3/Dockerfile.fedora
+++ b/containers/gtk3/Dockerfile.fedora
@@ -2,7 +2,8 @@ FROM docker.io/fedora:latest AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ARG APPDIR=/AppDir
-RUN dnf install -y wget librsvg2-devel file findutils pkgconfig gtk3 gtk3-devel
+RUN dnf install -y wget librsvg2-devel file findutils pkgconfig gtk3 gtk3-devel \
+    gobject-introspection-devel
 COPY . .
 ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
 RUN chmod +x *.sh *.AppImage

--- a/containers/gtk3/Dockerfile.opensuse
+++ b/containers/gtk3/Dockerfile.opensuse
@@ -2,7 +2,8 @@ FROM docker.io/opensuse/leap:15 AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ARG APPDIR=/AppDir
-RUN zypper install -y wget librsvg2-devel file findutils pkg-config gtk3 gtk3-devel
+RUN zypper install -y wget librsvg2-devel file findutils pkg-config gtk3 gtk3-devel \
+    typelib-1_0-Gtk-3_0 gobject-introspection-devel
 COPY . .
 ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
 RUN chmod +x *.sh *.AppImage

--- a/containers/gtk3/Dockerfile.ubuntu
+++ b/containers/gtk3/Dockerfile.ubuntu
@@ -6,7 +6,8 @@ ARG APPDIR=/AppDir
 ARG TZ=UTC
 RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
 RUN apt-get update && \
-    apt-get install -y wget librsvg2-dev file findutils pkg-config libgtk-3-0 libgtk-3-dev gtk-3-examples
+    apt-get install -y wget librsvg2-dev file findutils pkg-config libgtk-3-0 \
+    libgtk-3-dev gtk-3-examples gir1.2-gtk-3.0
 COPY . .
 ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
 RUN chmod +x *.sh *.AppImage

--- a/containers/gtk4/Dockerfile.debian
+++ b/containers/gtk4/Dockerfile.debian
@@ -8,7 +8,7 @@ ARG TZ=UTC
 RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
 RUN apt-get update && \
     apt-get install -y wget librsvg2-dev file findutils pkg-config && \
-    apt-get install -y -t experimental libgtk-4-1 libgtk-4-dev gtk-4-examples
+    apt-get install -y -t experimental libgtk-4-1 libgtk-4-dev gtk-4-examples gir1.2-gtk-4.0
 COPY . .
 ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
 RUN chmod +x *.sh *.AppImage

--- a/containers/gtk4/Dockerfile.fedora
+++ b/containers/gtk4/Dockerfile.fedora
@@ -2,7 +2,8 @@ FROM docker.io/fedora:latest AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ARG APPDIR=/AppDir
-RUN dnf install -y wget librsvg2-devel file findutils pkgconfig gtk4 gtk4-devel gtk4-devel-tools
+RUN dnf install -y wget librsvg2-devel file findutils pkgconfig gtk4 gtk4-devel gtk4-devel-tools \
+    gobject-introspection-devel
 COPY . .
 ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
 RUN chmod +x *.sh *.AppImage

--- a/containers/gtk4/Dockerfile.opensuse
+++ b/containers/gtk4/Dockerfile.opensuse
@@ -3,7 +3,8 @@ FROM docker.io/opensuse/tumbleweed:latest AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ARG APPDIR=/AppDir
-RUN zypper install -y wget librsvg2-devel file findutils pkg-config gtk4 gtk4-devel
+RUN zypper install -y wget librsvg2-devel file findutils pkg-config gtk4 gtk4-devel \
+    typelib-1_0-Gtk-4_0 gobject-introspection-devel
 COPY . .
 ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
 RUN chmod +x *.sh *.AppImage

--- a/containers/gtk4/Dockerfile.ubuntu
+++ b/containers/gtk4/Dockerfile.ubuntu
@@ -6,7 +6,8 @@ ARG APPDIR=/AppDir
 ARG TZ=UTC
 RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
 RUN apt-get update && \
-    apt-get install -y wget librsvg2-dev file findutils pkg-config libgtk-4-1 libgtk-4-dev gtk-4-examples
+    apt-get install -y wget librsvg2-dev file findutils pkg-config libgtk-4-1 \
+    libgtk-4-dev gtk-4-examples gir1.2-gtk-4.0
 COPY . .
 ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
 RUN chmod +x *.sh *.AppImage

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -194,6 +194,13 @@ cat >> "$HOOKFILE" <<EOF
 export GSETTINGS_SCHEMA_DIR="\$APPDIR/$glib_schemasdir"
 EOF
 
+echo "Installing GIRepository Typelibs"
+gi_typelibsdir="$(get_pkgconf_variable "typelibdir" "gobject-introspection-1.0" "/usr/lib64/girepository-1.0")"
+copy_tree "$gi_typelibsdir" "$APPDIR/"
+cat >> "$HOOKFILE" <<EOF
+export GI_TYPELIB_PATH="\$APPDIR/$gi_typelibsdir"
+EOF
+
 case "$DEPLOY_GTK_VERSION" in
     2)
         # https://github.com/linuxdeploy/linuxdeploy-plugin-gtk/pull/20#issuecomment-826354261

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -309,6 +309,6 @@ PATCH_ARRAY=(
 )
 for directory in "${PATCH_ARRAY[@]}"; do
     while IFS= read -r -d '' file; do
-        ln $verbose -s "${file/\/usr\/lib\//}" "$APPDIR/usr/lib"
+        ln $verbose -sf "${file/\/usr\/lib\//}" "$APPDIR/usr/lib"
     done < <(find "$directory" -name '*.so' -print0)
 done

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -195,7 +195,7 @@ export GSETTINGS_SCHEMA_DIR="\$APPDIR/$glib_schemasdir"
 EOF
 
 echo "Installing GIRepository Typelibs"
-gi_typelibsdir="$(get_pkgconf_variable "typelibdir" "gobject-introspection-1.0" "/usr/lib64/girepository-1.0")"
+gi_typelibsdir="$(get_pkgconf_variable "typelibdir" "gobject-introspection-1.0" "/usr/lib/x86_64-linux-gnu/girepository-1.0")"
 copy_tree "$gi_typelibsdir" "$APPDIR/"
 cat >> "$HOOKFILE" <<EOF
 export GI_TYPELIB_PATH="\$APPDIR/$gi_typelibsdir"

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -208,11 +208,11 @@ case "$DEPLOY_GTK_VERSION" in
         ;;
     3)
         echo "Installing GTK 3.0 modules"
-        gtk3_exec_prefix="$(get_pkgconf_variable "exec_prefix" "gtk+-3.0")"
-        gtk3_libdir="$(get_pkgconf_variable "libdir" "gtk+-3.0")/gtk-3.0"
+        gtk3_exec_prefix="$(get_pkgconf_variable "exec_prefix" "gtk+-3.0" "/usr")"
+        gtk3_libdir="$(get_pkgconf_variable "libdir" "gtk+-3.0" "/usr/lib/x86_64-linux-gnu")/gtk-3.0"
         gtk3_path="$gtk3_libdir/modules"
-        gtk3_immodulesdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0")/immodules"
-        gtk3_printbackendsdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0")/printbackends"
+        gtk3_immodulesdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0" "3.0.0")/immodules"
+        gtk3_printbackendsdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0" "3.0.0")/printbackends"
         gtk3_immodules_cache_file="$(dirname "$gtk3_immodulesdir")/immodules.cache"
         gtk3_immodules_query="$(search_tool "gtk-query-immodules-3.0" "libgtk-3-0")"
         copy_tree "$gtk3_libdir" "$APPDIR/"
@@ -251,10 +251,10 @@ EOF
 esac
 
 echo "Installing GDK PixBufs"
-gdk_libdir="$(get_pkgconf_variable "libdir" "gdk-pixbuf-2.0")"
-gdk_pixbuf_binarydir="$(get_pkgconf_variable "gdk_pixbuf_binarydir" "gdk-pixbuf-2.0")"
-gdk_pixbuf_cache_file="$(get_pkgconf_variable "gdk_pixbuf_cache_file" "gdk-pixbuf-2.0")"
-gdk_pixbuf_moduledir="$(get_pkgconf_variable "gdk_pixbuf_moduledir" "gdk-pixbuf-2.0")"
+gdk_libdir="$(get_pkgconf_variable "libdir" "gdk-pixbuf-2.0" "/usr/lib/x86_64-linux-gnu")"
+gdk_pixbuf_binarydir="$(get_pkgconf_variable "gdk_pixbuf_binarydir" "gdk-pixbuf-2.0" "$gdk_libdir""/gdk-pixbuf-2.0/2.10.0")"
+gdk_pixbuf_cache_file="$(get_pkgconf_variable "gdk_pixbuf_cache_file" "gdk-pixbuf-2.0" "$gdk_pixbuf_binarydir""/loaders.cache")"
+gdk_pixbuf_moduledir="$(get_pkgconf_variable "gdk_pixbuf_moduledir" "gdk-pixbuf-2.0" "$gdk_pixbuf_binarydir""/loaders")"
 # Note: gdk_pixbuf_query_loaders variable is not defined on some systems
 gdk_pixbuf_query="$(search_tool "gdk-pixbuf-query-loaders" "gdk-pixbuf-2.0")"
 copy_tree "$gdk_pixbuf_binarydir" "$APPDIR/"
@@ -273,12 +273,12 @@ fi
 sed -i "s|$gdk_pixbuf_moduledir/||g" "$APPDIR/$gdk_pixbuf_cache_file"
 
 echo "Copying more libraries"
-gobject_libdir="$(get_pkgconf_variable "libdir" "gobject-2.0")"
-gio_libdir="$(get_pkgconf_variable "libdir" "gio-2.0")"
-librsvg_libdir="$(get_pkgconf_variable "libdir" "librsvg-2.0")"
-pango_libdir="$(get_pkgconf_variable "libdir" "pango")"
-pangocairo_libdir="$(get_pkgconf_variable "libdir" "pangocairo")"
-pangoft2_libdir="$(get_pkgconf_variable "libdir" "pangoft2")"
+gobject_libdir="$(get_pkgconf_variable "libdir" "gobject-2.0" "/usr/lib/x86_64-linux-gnu")"
+gio_libdir="$(get_pkgconf_variable "libdir" "gio-2.0" "/usr/lib/x86_64-linux-gnu")"
+librsvg_libdir="$(get_pkgconf_variable "libdir" "librsvg-2.0" "/usr/lib/x86_64-linux-gnu")"
+pango_libdir="$(get_pkgconf_variable "libdir" "pango" "/usr/lib/x86_64-linux-gnu")"
+pangocairo_libdir="$(get_pkgconf_variable "libdir" "pangocairo" "/usr/lib/x86_64-linux-gnu")"
+pangoft2_libdir="$(get_pkgconf_variable "libdir" "pangoft2" "/usr/lib/x86_64-linux-gnu")"
 FIND_ARRAY=(
     "$gdk_libdir"     "libgdk_pixbuf-*.so*"
     "$gobject_libdir" "libgobject-*.so*"


### PR DESCRIPTION
This PR adds support for installing girepository typelibs and adds additional default pkg-config locations.

Currently, the plugin is not packaging any typelibs. These allow for apps that use other language bindings to be packaged using linuxdeploy. For example, PyGObject uses the typelibs to introspect bindings for Python.
    
Additionally, this PR adds additional default locations for Ubuntu in case libgtk-3-dev and librsvg2-dev are not installed. A Python app wouldn't normally require these dependencies, so use default values as a fallback during packaging for linuxdeploy. Although I don't use Ubuntu myself, this is the typical setup, especially with CI runners and Docker.

Finally, it fixes a small issue with the symbolic link step at the end, which fails if the symbolic links already exist.
