### PR TITLE
Fix CI

### DIFF
--- a/containers/gtk4/Dockerfile.ubuntu
+++ b/containers/gtk4/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:hirsute AS build-stage
+FROM docker.io/ubuntu:jammy AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -19,7 +19,7 @@ RUN ./linuxdeploy-x86_64.AppImage \
     --desktop-file /usr/share/applications/org.gtk.WidgetFactory4.desktop \
     --icon-file /usr/share/icons/hicolor/scalable/apps/org.gtk.WidgetFactory4.svg
 
-FROM docker.io/ubuntu:hirsute
+FROM docker.io/ubuntu:jammy
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1


### PR DESCRIPTION
I updated the runner to Ubuntu jammy (the latest LTS release)

Is there a reason why releases are pinned, rather than the `latest` tag ? I would like to update Dockerfiles to use it, to prevent future breakage