### PR TITLE
Normalize `APPDIR` to absolute path

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -149,6 +149,7 @@ if [ "$APPDIR" == "" ]; then
     exit 1
 fi
 
+APPDIR="$(realpath "$APPDIR")"
 mkdir -p "$APPDIR"
 
 if command -v pkgconf > /dev/null; then


### PR DESCRIPTION
Restores support for `APPDIR` being a relative path by always normalizing `APPDIR` to an absolute path.

Fixes regression from #45.

Tested against an `APPDIR` that's an absolute path or relative path (including a relative path to a symlink for the AppDir).