### PR TITLE
GTK library path handling fixes

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -77,15 +77,17 @@ copy_lib_tree() {
     done
 }
 
-get_triplet() {
+get_triplet_path() {
     if command -v dpkg-architecture > /dev/null; then
-        dpkg-architecture -qDEB_HOST_MULTIARCH
+        echo "/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
     fi
 }
 
+
+
 search_library_path() {
     PATH_ARRAY=(
-        "/usr/lib/$(get_triplet)"
+        "$(get_triplet_path)"
         "/usr/lib64"
         "/usr/lib"
     )
@@ -174,7 +176,9 @@ else
     echo "$0: pkg-config/pkgconf not found in PATH, aborting"
     exit 1
 fi
-LD_GTK_LIBRARY_PATH="${LD_GTK_LIBRARY_PATH:-$(search_library_path)}"
+
+# GTK's library path *must not* have a trailing slash for later parameter substitution to work properly
+LD_GTK_LIBRARY_PATH="$(realpath "${LD_GTK_LIBRARY_PATH:-$(search_library_path)}")"
 
 if ! command -v find &>/dev/null && ! type find &>/dev/null; then
     echo -e "$0: find not found.\nInstall findutils then re-run the plugin."


### PR DESCRIPTION
## Changes
- Do not prioritize `/usr/lib` or `/usr/lib64` if `dpkg-architecture` isn't found in the build environment
- Normalize `LD_GTK_LIBRARY_PATH` to avoid opaque parameter substitution issues with its use later

## Notes
- The original implementation would first try `/usr/lib/` if `dpkg-architecture` wasn't available. So, this would subtly prioritize `/usr/lib/` over `/usr/lib64`.
- But this also revealed the fragility of the parameter substitution of `LD_GTK_LIBRARY_PATH` later on....since we're implicitly assuming it doesn't end in a trailing slash.
- Specifically, something like this:
  - `$APPDIR/${gtk3_immodules_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}`
- can be resolved to this with a trailing slash:
  - `/app/Hello World.AppDir//usr/libgtk-3.0/3.0.0/immodules.cache`