### PR TITLE
Support Debian i386 in CI

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,4 +1,4 @@
-name: Containers
+name: GTK Widget Factory from containers
 
 on: [push, pull_request]
 

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -8,13 +8,22 @@ jobs:
       matrix:
         gtk-version: [gtk3, gtk4]
         linux-distro: [debian, fedora, opensuse, ubuntu]
+        arch: [amd64]
+        include:
+          - gtk-version: gtk3
+            linux-distro: debian
+            arch: 386
+          - gtk-version: gtk4
+            linux-distro: debian
+            arch: 386
 
-    name: ${{ matrix.linux-distro }} ${{ matrix.gtk-version }}
+    name: ${{ matrix.linux-distro }} ${{ matrix.arch }} ${{ matrix.gtk-version }}
     runs-on: ubuntu-latest
 
     env:
       GTK_VERSION: ${{ matrix.gtk-version }}
       LINUX_DISTRO: ${{ matrix.linux-distro }}
+      ARCHITECTURE: ${{ matrix.arch }}
       IMAGE_NAME: "linuxdeploy-plugin-${{ matrix.gtk-version }}:${{ matrix.linux-distro }}"
       CONTAINER_NAME: "${{ matrix.linux-distro }}-${{ matrix.gtk-version }}"
       ARTIFACT_DIR: "${{ github.workspace }}/AppImage"
@@ -23,19 +32,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set extra environment variables
+        run: |
+          case "${ARCHITECTURE}" in
+            386)   echo MACHINE="i386" >> "$GITHUB_ENV";;
+            amd64) echo MACHINE="x86_64" >> "$GITHUB_ENV";;
+          esac
+
       - name: Build container
         run: |
-          buildah bud --tag "${IMAGE_NAME}" --file "containers/${GTK_VERSION}/Dockerfile.${LINUX_DISTRO}" .
+          buildah bud --arch="${ARCHITECTURE}" --build-arg MACHINE="${MACHINE}" --tag "${IMAGE_NAME}" --file "containers/${GTK_VERSION}/Dockerfile.${LINUX_DISTRO}" .
 
       - name: Extract AppImage from container
         run: |
           mkdir --verbose --parents "${ARTIFACT_DIR}"
-          podman run --name "${CONTAINER_NAME}" --interactive --detach --rm --entrypoint /bin/bash "${IMAGE_NAME}"
-          podman cp "${CONTAINER_NAME}:/AppImage/Widget_Factory-x86_64.AppImage" "${ARTIFACT_DIR}"
+          podman run --arch="${ARCHITECTURE}" --name "${CONTAINER_NAME}" --interactive --detach --rm --entrypoint /bin/bash "${IMAGE_NAME}"
+          podman cp "${CONTAINER_NAME}:/AppImage/Widget_Factory.AppImage" "${ARTIFACT_DIR}"
           podman stop "${CONTAINER_NAME}" --time 0
 
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.linux-distro }} with ${{ matrix.gtk-version }}
+          name: ${{ matrix.gtk-version }}_${{ matrix.linux-distro }}_${{ env.MACHINE }}
           path: ${{ env.ARTIFACT_DIR }}/
           retention-days: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test plugin
 
 on: [push, pull_request]
 

--- a/containers/gtk3/Dockerfile.debian
+++ b/containers/gtk3/Dockerfile.debian
@@ -2,6 +2,7 @@ FROM docker.io/debian:buster AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ENV DEBIAN_FRONTEND=noninteractive
+ARG MACHINE=x86_64
 ARG APPDIR=/AppDir
 ARG TZ=UTC
 RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
@@ -9,9 +10,9 @@ RUN apt-get update && \
     apt-get install -y dpkg-dev wget librsvg2-dev file findutils pkg-config libgtk-3-0 \
     libgtk-3-dev gtk-3-examples gir1.2-gtk-3.0 libgirepository1.0-dev
 COPY . .
-ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
-RUN chmod +x *.sh *.AppImage
-RUN ./linuxdeploy-x86_64.AppImage \
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" "linuxdeploy-${MACHINE}.AppImage"
+RUN chmod --verbose +x *.sh *.AppImage
+RUN ./linuxdeploy-${MACHINE}.AppImage \
     --appdir ${APPDIR} \
     --plugin gtk \
     --output appimage \
@@ -23,5 +24,6 @@ FROM docker.io/debian:buster
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1
-COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
-ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]
+ARG MACHINE=x86_64
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-${MACHINE}.AppImage" "./Widget_Factory.AppImage"
+ENTRYPOINT ["./Widget_Factory.AppImage"]

--- a/containers/gtk3/Dockerfile.fedora
+++ b/containers/gtk3/Dockerfile.fedora
@@ -1,14 +1,15 @@
 FROM docker.io/fedora:latest AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
+ARG MACHINE=x86_64
 ARG APPDIR=/AppDir
 RUN dnf install -y wget librsvg2-devel file findutils pkgconfig gtk3 gtk3-devel \
     gobject-introspection-devel
 COPY . .
-ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
-RUN chmod +x *.sh *.AppImage
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" .
+RUN chmod --verbose +x *.sh *.AppImage
 RUN gtk-query-immodules-3.0-64 --update-cache
-RUN ./linuxdeploy-x86_64.AppImage \
+RUN ./linuxdeploy-${MACHINE}.AppImage \
     --appdir ${APPDIR} \
     --plugin gtk \
     --output appimage \
@@ -20,5 +21,6 @@ FROM docker.io/fedora:latest
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1
-COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
-ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]
+ARG MACHINE=x86_64
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-${MACHINE}.AppImage" "./Widget_Factory.AppImage"
+ENTRYPOINT ["./Widget_Factory.AppImage"]

--- a/containers/gtk3/Dockerfile.opensuse
+++ b/containers/gtk3/Dockerfile.opensuse
@@ -1,13 +1,14 @@
 FROM docker.io/opensuse/leap:15 AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
+ARG MACHINE=x86_64
 ARG APPDIR=/AppDir
 RUN zypper install -y wget librsvg2-devel file findutils pkg-config gtk3 gtk3-devel \
     typelib-1_0-Gtk-3_0 gobject-introspection-devel
 COPY . .
-ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
-RUN chmod +x *.sh *.AppImage
-RUN ./linuxdeploy-x86_64.AppImage \
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" .
+RUN chmod --verbose +x *.sh *.AppImage
+RUN ./linuxdeploy-${MACHINE}.AppImage \
     --appdir ${APPDIR} \
     --plugin gtk \
     --output appimage \
@@ -19,5 +20,6 @@ FROM docker.io/opensuse/leap:15
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1
-COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
-ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]
+ARG MACHINE=x86_64
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-${MACHINE}.AppImage" "./Widget_Factory.AppImage"
+ENTRYPOINT ["./Widget_Factory.AppImage"]

--- a/containers/gtk3/Dockerfile.ubuntu
+++ b/containers/gtk3/Dockerfile.ubuntu
@@ -2,6 +2,7 @@ FROM docker.io/ubuntu:focal AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ENV DEBIAN_FRONTEND=noninteractive
+ARG MACHINE=x86_64
 ARG APPDIR=/AppDir
 ARG TZ=UTC
 RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
@@ -9,9 +10,9 @@ RUN apt-get update && \
     apt-get install -y dpkg-dev wget librsvg2-dev file findutils pkg-config libgtk-3-0 \
     libgtk-3-dev gtk-3-examples gir1.2-gtk-3.0 libgirepository1.0-dev libfuse2
 COPY . .
-ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
-RUN chmod +x *.sh *.AppImage
-RUN ./linuxdeploy-x86_64.AppImage \
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" .
+RUN chmod --verbose +x *.sh *.AppImage
+RUN ./linuxdeploy-${MACHINE}.AppImage \
     --appdir ${APPDIR} \
     --plugin gtk \
     --output appimage \
@@ -23,5 +24,6 @@ FROM docker.io/ubuntu:focal
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1
-COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
-ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]
+ARG MACHINE=x86_64
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-${MACHINE}.AppImage" "./Widget_Factory.AppImage"
+ENTRYPOINT ["./Widget_Factory.AppImage"]

--- a/containers/gtk4/Dockerfile.debian
+++ b/containers/gtk4/Dockerfile.debian
@@ -2,6 +2,7 @@ FROM docker.io/debian:bookworm AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ENV DEBIAN_FRONTEND=noninteractive
+ARG MACHINE=x86_64
 ARG APPDIR=/AppDir
 ARG TZ=UTC
 RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
@@ -9,9 +10,9 @@ RUN apt-get update && \
     apt-get install -y dpkg-dev wget librsvg2-dev file findutils pkg-config && \
     apt-get install -y libgtk-4-1 libgtk-4-dev gtk-4-examples gir1.2-gtk-4.0 libgirepository1.0-dev
 COPY . .
-ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
-RUN chmod +x *.sh *.AppImage
-RUN ./linuxdeploy-x86_64.AppImage \
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" .
+RUN chmod --verbose +x *.sh *.AppImage
+RUN ./linuxdeploy-${MACHINE}.AppImage \
     --appdir ${APPDIR} \
     --plugin gtk \
     --output appimage \
@@ -23,5 +24,6 @@ FROM docker.io/debian:bookworm
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1
-COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
-ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]
+ARG MACHINE=x86_64
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-${MACHINE}.AppImage" "./Widget_Factory.AppImage"
+ENTRYPOINT ["./Widget_Factory.AppImage"]

--- a/containers/gtk4/Dockerfile.fedora
+++ b/containers/gtk4/Dockerfile.fedora
@@ -1,13 +1,14 @@
 FROM docker.io/fedora:latest AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
+ARG MACHINE=x86_64
 ARG APPDIR=/AppDir
 RUN dnf install -y wget librsvg2-devel file findutils pkgconfig gtk4 gtk4-devel gtk4-devel-tools \
     gobject-introspection-devel
 COPY . .
-ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
-RUN chmod +x *.sh *.AppImage
-RUN ./linuxdeploy-x86_64.AppImage \
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" .
+RUN chmod --verbose +x *.sh *.AppImage
+RUN ./linuxdeploy-${MACHINE}.AppImage \
     --appdir ${APPDIR} \
     --plugin gtk \
     --output appimage \
@@ -19,5 +20,6 @@ FROM docker.io/fedora:latest
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1
-COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
-ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]
+ARG MACHINE=x86_64
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-${MACHINE}.AppImage" "./Widget_Factory.AppImage"
+ENTRYPOINT ["./Widget_Factory.AppImage"]

--- a/containers/gtk4/Dockerfile.opensuse
+++ b/containers/gtk4/Dockerfile.opensuse
@@ -2,13 +2,14 @@
 FROM docker.io/opensuse/tumbleweed:latest AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
+ARG MACHINE=x86_64
 ARG APPDIR=/AppDir
 RUN zypper install -y wget librsvg2-devel file findutils pkg-config gtk4 gtk4-devel \
     typelib-1_0-Gtk-4_0 gobject-introspection-devel
 COPY . .
-ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
-RUN chmod +x *.sh *.AppImage
-RUN ./linuxdeploy-x86_64.AppImage \
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" .
+RUN chmod --verbose +x *.sh *.AppImage
+RUN ./linuxdeploy-${MACHINE}.AppImage \
     --appdir ${APPDIR} \
     --plugin gtk \
     --output appimage \
@@ -20,5 +21,6 @@ FROM docker.io/opensuse/tumbleweed:latest
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1
-COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
-ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]
+ARG MACHINE=x86_64
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-${MACHINE}.AppImage" "./Widget_Factory.AppImage"
+ENTRYPOINT ["./Widget_Factory.AppImage"]

--- a/containers/gtk4/Dockerfile.ubuntu
+++ b/containers/gtk4/Dockerfile.ubuntu
@@ -2,6 +2,7 @@ FROM docker.io/ubuntu:jammy AS build-stage
 WORKDIR /linuxdeploy
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 ENV DEBIAN_FRONTEND=noninteractive
+ARG MACHINE=x86_64
 ARG APPDIR=/AppDir
 ARG TZ=UTC
 RUN ln -snf "/usr/share/zoneinfo/$TZ" "/etc/localtime" && echo "$TZ" > /etc/timezone
@@ -9,9 +10,9 @@ RUN apt-get update && \
     apt-get install -y dpkg-dev wget librsvg2-dev file findutils pkg-config libgtk-4-1 \
     libgtk-4-dev gtk-4-examples gir1.2-gtk-4.0 libgirepository1.0-dev libfuse2
 COPY . .
-ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" .
-RUN chmod +x *.sh *.AppImage
-RUN ./linuxdeploy-x86_64.AppImage \
+ADD "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" .
+RUN chmod --verbose +x *.sh *.AppImage
+RUN ./linuxdeploy-${MACHINE}.AppImage \
     --appdir ${APPDIR} \
     --plugin gtk \
     --output appimage \
@@ -23,5 +24,6 @@ FROM docker.io/ubuntu:jammy
 VOLUME ["/AppImage"]
 WORKDIR /AppImage
 ENV APPIMAGE_EXTRACT_AND_RUN=1
-COPY --from=build-stage "/linuxdeploy/Widget_Factory-x86_64.AppImage" .
-ENTRYPOINT ["./Widget_Factory-x86_64.AppImage"]
+ARG MACHINE=x86_64
+COPY --from=build-stage "/linuxdeploy/Widget_Factory-${MACHINE}.AppImage" "./Widget_Factory.AppImage"
+ENTRYPOINT ["./Widget_Factory.AppImage"]


### PR DESCRIPTION
As suggested by @rmartin16 in #52, it would be better to support i386 (when available) in order to avoid issue like #50.
This PR adds a new `arch` field in the matrix that can be extended thanks to the  [`jobs.<job_id>.strategy.matrix.include`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude) keyword. Only Debian still support i386, so there are 4 jobs for Debian (GTK3/4 i386/amd64) but no changes for other distro.