### PR TITLE
Fix multiarch triplet library for `search_tool`

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -109,7 +109,7 @@ search_tool() {
     fi
 
     PATH_ARRAY=(
-        "/usr/lib/$(get_triplet)/$directory/$tool"
+        "$(get_triplet_path)/$directory/$tool"
         "/usr/lib64/$directory/$tool"
         "/usr/lib/$directory/$tool"
         "/usr/bin/$tool"


### PR DESCRIPTION
Missed this in #52 but `search_tool` needed to be updated as well. This isn't ideal since `get_triplet_path` can return empty but the likelihood of finding `directory` in the root of the filesystem seems particularly low.