### PR TITLE
Prefer color-scheme from org.freedesktop.portal.Desktop

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -226,10 +226,14 @@ mkdir -p "$HOOKSDIR"
 cat > "$HOOKFILE" <<\EOF
 #! /usr/bin/env bash
 
-case "$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)" in
-    "'prefer-dark'")  GTK_THEME_VARIANT="dark";;
-    "'prefer-light'") GTK_THEME_VARIANT="light";;
-    *)                GTK_THEME_VARIANT="light";;
+COLOR_SCHEME="$(dbus-send --session --dest=org.freedesktop.portal.Desktop --type=method_call --print-reply --reply-timeout=1000 /org/freedesktop/portal/desktop org.freedesktop.portal.Settings.Read 'string:org.freedesktop.appearance' 'string:color-scheme' 2>/dev/null | tail -n1 | cut -b35- | cut -d' ' -f2)"
+if [ -z "$COLOR_SCHEME" ]; then
+    COLOR_SCHEME="$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null)"
+fi
+case "$COLOR_SCHEME" in
+    "1"|"'prefer-dark'")  GTK_THEME_VARIANT="dark";;
+    "2"|"'prefer-light'") GTK_THEME_VARIANT="light";;
+    *)                    GTK_THEME_VARIANT="light";;
 esac
 APPIMAGE_GTK_THEME="${APPIMAGE_GTK_THEME:-"Adwaita:$GTK_THEME_VARIANT"}" # Allow user to override theme (discouraged)
 


### PR DESCRIPTION
In some distros GNOME 42 or later versions are not available, thus querying color-scheme will return an error.

Ref: https://github.com/xournalpp/xournalpp/issues/5152